### PR TITLE
chore(winget): update manifest version to 1.6.0

### DIFF
--- a/packages/winget/JanDeDobbeleer.Aliae.installer.yaml
+++ b/packages/winget/JanDeDobbeleer.Aliae.installer.yaml
@@ -47,4 +47,4 @@ Installers:
   InstallerSwitches:
      Custom: /INSTALLER=winget /CURRENTUSER
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.6.0

--- a/packages/winget/JanDeDobbeleer.Aliae.locale.en-US.yaml
+++ b/packages/winget/JanDeDobbeleer.Aliae.locale.en-US.yaml
@@ -26,6 +26,5 @@ Tags:
 - "aliae"
 - "dotfiles"
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0
 ReleaseNotesUrl: https://github.com/JanDeDobbeleer/aliae/releases/tag/v<VERSION>
-

--- a/packages/winget/JanDeDobbeleer.Aliae.locale.en-US.yaml
+++ b/packages/winget/JanDeDobbeleer.Aliae.locale.en-US.yaml
@@ -26,5 +26,5 @@ Tags:
 - "aliae"
 - "dotfiles"
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0
 ReleaseNotesUrl: https://github.com/JanDeDobbeleer/aliae/releases/tag/v<VERSION>

--- a/packages/winget/JanDeDobbeleer.Aliae.yaml
+++ b/packages/winget/JanDeDobbeleer.Aliae.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: JanDeDobbeleer.Aliae
 PackageVersion: <VERSION>
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0

--- a/packages/winget/JanDeDobbeleer.Aliae.yaml
+++ b/packages/winget/JanDeDobbeleer.Aliae.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: JanDeDobbeleer.Aliae
 PackageVersion: <VERSION>
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

Manifest version 1.4.0 and lower have been deprecated.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
