### PR TITLE
feat: adding !include and !include_dir

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -36,13 +36,10 @@ linters-settings:
   gocritic:
     enabled-tags:
       - diagnostic
-      - experimental
       - opinionated
       - performance
       - style
     disabled-tags:
       - experimental
-    disabled-checks:
-      - ifElseChain
   lll:
     line-length: 180

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/aliae/src/shell"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveConfigPath(t *testing.T) {
+	cases := []struct {
+		name      string
+		configVar string
+		homeVar   string
+		expected  string
+	}{
+		{"Config env var", "test", "", "test"},
+		{"No config env var", "", "/home", "/home/.aliae.yaml"},
+		{"No config env var, no home", "", "", ".aliae.yaml"},
+	}
+
+	for _, c := range cases {
+		os.Setenv("ALIAE_CONFIG", c.configVar)
+		os.Setenv("HOME", c.homeVar)
+		got := resolveConfigPath("")
+		assert.Equal(t, got, got, c.name)
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      string
+		expected    *Aliae
+		expectError bool
+	}{
+		{
+			"Valid",
+			"aliae.valid.yaml",
+			&Aliae{
+				Aliae: shell.Aliae{
+					{Name: "test", Value: shell.Template("test")},
+					{Name: "test2", Value: shell.Template("test2")},
+				},
+				Envs: shell.Envs{
+					{Name: "TEST_ENV", Value: "test"},
+				},
+			},
+			false,
+		},
+		{
+			"Invalid",
+			"aliae.invalid.yaml",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		configFile := filepath.Join("test", tc.config)
+		got, err := LoadConfig(configFile)
+
+		if tc.expectError {
+			assert.Error(t, err, tc.name)
+		} else {
+			assert.NoError(t, err, tc.name)
+		}
+
+		assert.Equal(t, tc.expected, got, tc.name)
+	}
+}

--- a/src/config/test/aliae.invalid.yaml
+++ b/src/config/test/aliae.invalid.yaml
@@ -1,0 +1,1 @@
+alias: !include ../include_invalid/alias.yaml

--- a/src/config/test/aliae.valid.yaml
+++ b/src/config/test/aliae.valid.yaml
@@ -1,0 +1,2 @@
+alias: !include_dir ./aliases
+env: !include ./envs/env.yaml

--- a/src/config/test/aliases/aliases.yaml
+++ b/src/config/test/aliases/aliases.yaml
@@ -1,0 +1,2 @@
+- name: test
+  value: test

--- a/src/config/test/aliases/aliases2.yaml
+++ b/src/config/test/aliases/aliases2.yaml
@@ -1,0 +1,2 @@
+- name: test2
+  value: test2

--- a/src/config/test/envs/env.yaml
+++ b/src/config/test/envs/env.yaml
@@ -1,0 +1,2 @@
+- name: TEST_ENV
+  value: test

--- a/src/config/test/files/test.yaml
+++ b/src/config/test/files/test.yaml
@@ -1,0 +1,1 @@
+it exists

--- a/src/config/test/files/test2.yaml
+++ b/src/config/test/files/test2.yaml
@@ -1,0 +1,1 @@
+it exists2

--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+	"github.com/jandedobbeleer/aliae/src/shell"
+)
+
+type Aliae struct {
+	Aliae   shell.Aliae   `yaml:"alias"`
+	Envs    shell.Envs    `yaml:"env"`
+	Paths   shell.Paths   `yaml:"path"`
+	Scripts shell.Scripts `yaml:"script"`
+}
+
+func customUnmarshaler(a *Aliae, b []byte) error {
+	data, err := includeUnmarshaler(b)
+	if err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewBuffer(data))
+	if err = decoder.Decode(a); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// includeUnmarshaler handles unmarshaling of !include and !include_dir tags
+func includeUnmarshaler(b []byte) ([]byte, error) {
+	s := strings.Split(string(b), "\n")
+
+	includeFuncMap := map[string]func([]string) (string, error){
+		"!include_dir": getDirFiles,
+		"!include":     getFile,
+	}
+
+	for i, line := range s {
+		for key, f := range includeFuncMap {
+			if !strings.HasPrefix(line, key) {
+				continue
+			}
+
+			parts := strings.Fields(line)
+			if len(parts) < 2 {
+				return nil, fmt.Errorf("invalid %s directive: \n%s", key, line)
+			}
+
+			data, err := f(parts[1:])
+			if err != nil {
+				return nil, err
+			}
+
+			s[i] = data
+			break
+		}
+	}
+
+	returnData := []byte(strings.Join(s, "\n"))
+	if len(returnData) == len(b) {
+		return returnData, nil
+	}
+
+	return includeUnmarshaler(returnData)
+}
+
+func trimQuotes(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+
+	if s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+
+	return s
+}
+
+func getFile(s []string) (string, error) {
+	// Allows for templating in the file path
+	file := shell.Template(trimQuotes(strings.Join(s, ""))).Parse().String()
+
+	// check if filepath is relative
+	file, err := relativePath(file)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func getDirFiles(d []string) (string, error) {
+	// Allows for templating in the directory path
+	dir := shell.Template(trimQuotes(strings.Join(d, ""))).Parse().String()
+
+	// check if filepath is relative
+	dir, err := relativePath(dir)
+	if err != nil {
+		return "", err
+	}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return "", err
+	}
+
+	var configData strings.Builder
+
+	for _, file := range files {
+		if !isYAMLExtension(file.Name()) {
+			continue
+		}
+
+		filePath := filepath.Join(dir, file.Name())
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", err
+		}
+
+		configData.WriteString("\n")
+		configData.Write(data)
+	}
+
+	return configData.String(), nil
+}
+
+func relativePath(path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+
+	if len(configPathCache) == 0 {
+		return "", errors.New("Config file not found")
+	}
+
+	if strings.HasPrefix(configPathCache, "https://") || strings.HasPrefix(configPathCache, "http://") {
+		return "", errors.New("Remote files are not allowed to contain include directives")
+	}
+
+	// get the directory of the config file
+	configPathCacheDir := filepath.Dir(configPathCache)
+
+	// append the file to the directory
+	path = filepath.Join(configPathCacheDir, path)
+
+	return path, nil
+}
+
+func isYAMLExtension(fileName string) bool {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	return ext == ".yml" || ext == ".yaml"
+}

--- a/src/config/unmarshal_test.go
+++ b/src/config/unmarshal_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimQuotes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"NoQuotes", "test", "test"},
+		{"DoubleQuotes", "\"test\"", "test"},
+		{"SingleQuotes", "'test'", "'test'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimQuotes(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetFile(t *testing.T) {
+	t.Run("ValidFile", func(t *testing.T) {
+		testDirPath := filepath.Join("test", "files", "test.yaml")
+		absPath, _ := filepath.Abs(testDirPath)
+		content, err := getFile([]string{absPath})
+		assert.NoError(t, err)
+		assert.Equal(t, "it exists", content)
+	})
+
+	t.Run("NonExistentFile", func(t *testing.T) {
+		_, err := getFile([]string{"path/to/nonexistent/file.txt"})
+		assert.Error(t, err)
+	})
+}
+
+func TestGetDirFiles(t *testing.T) {
+	t.Run("ValidDir", func(t *testing.T) {
+		testDirPath := filepath.Join("test", "files")
+		absPath, _ := filepath.Abs(testDirPath)
+		content, err := getDirFiles([]string{absPath})
+		assert.NoError(t, err)
+		assert.Equal(t, "\nit exists\nit exists2", content)
+	})
+
+	t.Run("NonExistentDir", func(t *testing.T) {
+		_, err := getDirFiles([]string{"path/to/nonexistent/dir"})
+		assert.Error(t, err)
+	})
+}
+
+func TestRelativePath(t *testing.T) {
+	t.Run("RelativePath", func(t *testing.T) {
+		absPath, err := filepath.Abs("./test/files")
+		assert.NoError(t, err)
+		result, err := relativePath(absPath)
+		assert.NoError(t, err)
+		assert.Equal(t, absPath, result)
+	})
+
+	t.Run("HttpConfig", func(t *testing.T) {
+		configPathCache = "https://example.com/config.yaml"
+		_, err := relativePath("path/to/nonex	istent/dir")
+		assert.Error(t, err)
+	})
+}
+
+func TestIsYamlExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{"YamlExtension", "test.yaml", true},
+		{"YmlExtension", "test.yml", true},
+		{"NoExtension", "test", false},
+		{"InvalidExtension", "test.txt", false},
+	}
+
+	for _, tc := range tests {
+		got := isYAMLExtension(tc.input)
+		assert.Equal(t, tc.expected, got, tc.name)
+	}
+}

--- a/website/docs/setup/include.mdx
+++ b/website/docs/setup/include.mdx
@@ -1,0 +1,27 @@
+---
+id: include
+title: Include
+sidebar_label: ➕ Include files
+---
+
+## Example
+
+```yaml title=".aliae.yaml"
+aliae: !include "{{ .Home }}/.aliae/aliases.yaml"
+env: !include_dir "{{ .Home }}/.aliae/envs"
+```
+
+```yaml title="$HOME/.aliae/aliases.yaml"
+- name: g
+  value: git
+- name: k
+  value: kubectl
+```
+
+## Description
+
+The `!include` and `!include_dir` yaml tags allow you to include a single file or a directory of .yaml files respectively.
+This allows for clean organization of aliae, envs, and all other things handled by Aliae.
+File/Directory paths support [templating][templates]
+
+[templates]: templates.mdx

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -24,6 +24,7 @@ module.exports = {
         "setup/script",
         "setup/if",
         "setup/templates",
+        "setup/include"
       ],
     },
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Reasoning
With this project being focused on cleaning up shell startups and organizing `dotfiles` it seems like a generally good strategy to not have a gigantic single `.aliae.yaml` file.

Technically this _can_ be accomplished with multiple calls to `aliae` and changing the `--config` parameter each time, but that is clunky and not very intuitive.

This brings the generally accepted yaml tag of "!include" as well as "!include_dir" to aliae. I searched around for any go-yaml libraries that had native support for adding tags to yaml unmarshaling, but came up empty handed. goccy/go-yaml does not provide a fantastic way to process yaml tags so preprocessing is required.

With the preprocessing I wanted it to have a few features:
1. !include - Include a file directly
2. !include_dir - Include an entire directory of .yaml files, allowing "infinite" management
3. Imports are templated (i.e. "{{.Home}}" works)
4. Imports accept relative imports (i.e. "./<file>" works)
5. Recursive imports

Due to a few of these "requirements" I had to move around some things to avoid cyclical imports, mostly the logic around getting the config file location so that relative imports work.



If there are any questions or suggestions I am happy to hear anything!

Thanks for this awesome tool!
