### PR TITLE
feat: env array

### DIFF
--- a/src/shell/env.go
+++ b/src/shell/env.go
@@ -15,6 +15,7 @@ type Env struct {
 	Delimiter Template    `yaml:"delimiter"`
 	If        If          `yaml:"if"`
 	Persist   bool        `yaml:"persist"`
+	Type      EnvType     `yaml:"type"`
 
 	template string
 	parsed   bool
@@ -155,3 +156,10 @@ func filterEmpty[S ~[]E, E string](s S) S {
 	}
 	return cleaned
 }
+
+type EnvType string
+
+const (
+	String EnvType = "string"
+	Array  EnvType = "array"
+)

--- a/src/shell/env_test.go
+++ b/src/shell/env_test.go
@@ -8,51 +8,99 @@ import (
 )
 
 func TestEnvironmentVariable(t *testing.T) {
-	env := &Env{Name: "HELLO", Value: "world"}
+	envs := map[EnvType]Env{
+		String: {Name: "HELLO", Value: "world"},
+		Array:  {Name: "ARRAY", Value: "hello array world", Type: "array"},
+	}
 	cases := []struct {
 		Case     string
+		Env      Env
 		Shell    string
 		Expected string
 	}{
 		{
 			Case:     "PWSH",
 			Shell:    PWSH,
+			Env:      envs[String],
 			Expected: `$env:HELLO = "world"`,
+		},
+		{
+			Case:     "PWSH Array",
+			Shell:    PWSH,
+			Env:      envs[Array],
+			Expected: `$env:ARRAY = @("hello","array","world")`,
 		},
 		{
 			Case:     "CMD",
 			Shell:    CMD,
+			Env:      envs[String],
 			Expected: `os.setenv("HELLO", "world")`,
 		},
 		{
 			Case:     "FISH",
 			Shell:    FISH,
+			Env:      envs[String],
 			Expected: "set --global HELLO world",
+		},
+		{
+			Case:     "FISH Array",
+			Shell:    FISH,
+			Env:      envs[Array],
+			Expected: "set --global ARRAY hello array world",
 		},
 		{
 			Case:     "NU",
 			Shell:    NU,
+			Env:      envs[String],
 			Expected: `    $env.HELLO = "world"`,
+		},
+		{
+			Case:     "NU Array",
+			Shell:    NU,
+			Env:      envs[Array],
+			Expected: `    $env.ARRAY = ["hello" "array" "world"]`,
 		},
 		{
 			Case:     "TCSH",
 			Shell:    TCSH,
+			Env:      envs[String],
 			Expected: `setenv HELLO "world";`,
 		},
 		{
 			Case:     "XONSH",
 			Shell:    XONSH,
+			Env:      envs[String],
 			Expected: `$HELLO = "world"`,
+		},
+		{
+			Case:     "XONSH Array",
+			Shell:    XONSH,
+			Env:      envs[Array],
+			Expected: `$ARRAY = ["hello","array","world"]`,
 		},
 		{
 			Case:     "ZSH",
 			Shell:    ZSH,
+			Env:      envs[String],
 			Expected: `export HELLO="world"`,
+		},
+		{
+			Case:     "ZSH Array",
+			Shell:    ZSH,
+			Env:      envs[Array],
+			Expected: `export ARRAY=("hello" "array" "world")`,
 		},
 		{
 			Case:     "BASH",
 			Shell:    BASH,
+			Env:      envs[String],
 			Expected: `export HELLO="world"`,
+		},
+		{
+			Case:     "BASH Array",
+			Shell:    BASH,
+			Env:      envs[Array],
+			Expected: `export ARRAY=("hello" "array" "world")`,
 		},
 		{
 			Case:  "Unknown",
@@ -61,9 +109,9 @@ func TestEnvironmentVariable(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env.template = ""
+		tc.Env.template = ""
 		context.Current = &context.Runtime{Shell: tc.Shell}
-		assert.Equal(t, tc.Expected, env.string(), tc.Case)
+		assert.Equal(t, tc.Expected, tc.Env.string(), tc.Case)
 	}
 }
 

--- a/src/shell/nu.go
+++ b/src/shell/nu.go
@@ -33,7 +33,15 @@ func (e *Echo) nu() *Echo {
 }
 
 func (e *Env) nu() *Env {
-	e.template = `    $env.{{ .Name }} = {{ formatString .Value }}`
+	switch e.Type {
+	case Array:
+		e.template = `    $env.{{ .Name }} = [{{ formatArray .Value }}]`
+	case String:
+		fallthrough
+	default:
+		e.template = `    $env.{{ .Name }} = {{ formatString .Value }}`
+	}
+
 	return e
 }
 

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -55,7 +55,15 @@ Write-Host $message`
 }
 
 func (e *Env) pwsh() *Env {
-	e.template = `$env:{{ .Name }} = {{ formatString .Value }}`
+	switch e.Type {
+	case Array:
+		e.template = `$env:{{ .Name }} = @({{ formatArray .Value "," }})`
+	case String:
+		fallthrough
+	default:
+		e.template = `$env:{{ .Name }} = {{ formatString .Value }}`
+	}
+
 	return e
 }
 

--- a/src/shell/template_test.go
+++ b/src/shell/template_test.go
@@ -35,3 +35,170 @@ func TestFormatString(t *testing.T) {
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }
+
+// This tests both formatArray and splitString
+func TestFormatArray(t *testing.T) {
+	text := `{{ formatArray .Value }}`
+	textDelim := `{{ formatArray .Value .Delim }}`
+	cases := []struct {
+		Case     string
+		Value    interface{}
+		Expected string
+		Delim    string
+	}{
+		{
+			Case:     "string",
+			Value:    "hello",
+			Expected: `"hello"`,
+		},
+		{
+			Case:     "Multiple Strings",
+			Value:    "hello world, I am a long string",
+			Expected: `"hello" "world," "I" "am" "a" "long" "string"`,
+		},
+		{
+			Case: "Multiline String",
+			Value: `hello
+world
+I
+am
+a
+multiline
+string`,
+			Expected: `"hello" "world" "I" "am" "a" "multiline" "string"`,
+		},
+		{
+			Case: "Single Line Starts with newline",
+			Value: `
+hello world I am a long string`,
+			Expected: `"hello" "world" "I" "am" "a" "long" "string"`,
+		},
+		{
+			Case:     "Single line with delimiter",
+			Value:    `hello world I am a long string`,
+			Delim:    ",",
+			Expected: `"hello","world","I","am","a","long","string"`,
+		},
+		{
+			Case: "Multiline with delimiter",
+			Value: `hello
+I
+am
+a
+mutliline
+string`,
+			Delim:    ";",
+			Expected: `"hello";"I";"am";"a";"mutliline";"string"`,
+		},
+		{
+			Case:     "bool",
+			Value:    true,
+			Expected: `true`,
+		},
+		{
+			Case:     "int",
+			Value:    32,
+			Expected: `32`,
+		},
+	}
+
+	for _, tc := range cases {
+		got := ""
+		if tc.Delim == "" {
+			got, _ = parse(text, tc)
+		} else {
+			got, _ = parse(textDelim, tc)
+		}
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestEscapeString(t *testing.T) {
+	text := `{{ escapeString .Value}}`
+	cases := []struct {
+		Case     string
+		Value    interface{}
+		Expected string
+	}{
+		{
+			Case:     "string",
+			Value:    `hello`,
+			Expected: `hello`,
+		},
+		{
+			Case:     "stringWithQuotes",
+			Value:    `hello "world"`,
+			Expected: `hello \"world\"`,
+		},
+		{
+			Case:     "stringWithBackslashes",
+			Value:    `hello \world`,
+			Expected: `hello \\world`,
+		},
+		{
+			Case:     "template",
+			Value:    Template(`hello "world"`),
+			Expected: `hello \"world\"`,
+		},
+	}
+
+	for _, tc := range cases {
+		got, _ := parse(text, tc)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestMatch(t *testing.T) {
+	text := `{{ match .Variable "hello" "world"}}`
+	cases := []struct {
+		Case     string
+		Variable string
+		Expected string
+	}{
+		{
+			Case:     "match",
+			Variable: "hello",
+			Expected: `true`,
+		},
+		{
+			Case:     "match",
+			Variable: "world",
+			Expected: `true`,
+		},
+		{
+			Case:     "noMatch",
+			Variable: "goodbye",
+			Expected: `false`,
+		},
+	}
+
+	for _, tc := range cases {
+		got, _ := parse(text, tc)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestHasCommand(t *testing.T) {
+	text := `{{ hasCommand .Command}}`
+	cases := []struct {
+		Case     string
+		Command  string
+		Expected string
+	}{
+		{
+			Case:     "hasCommand",
+			Command:  "go",
+			Expected: `true`,
+		},
+		{
+			Case:     "noCommand",
+			Command:  "notACommand",
+			Expected: `false`,
+		},
+	}
+
+	for _, tc := range cases {
+		got, _ := parse(text, tc)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}

--- a/src/shell/xonsh.go
+++ b/src/shell/xonsh.go
@@ -32,7 +32,15 @@ print(message)`
 }
 
 func (e *Env) xonsh() *Env {
-	e.template = `${{ .Name }} = {{ formatString .Value }}`
+	switch e.Type {
+	case Array:
+		e.template = `${{ .Name }} = [{{ formatArray .Value "," }}]`
+	case String:
+		fallthrough
+	default:
+		e.template = `${{ .Name }} = {{ formatString .Value }}`
+	}
+
 	return e
 }
 

--- a/src/shell/zsh.go
+++ b/src/shell/zsh.go
@@ -30,7 +30,15 @@ func (e *Echo) zsh() *Echo {
 }
 
 func (e *Env) zsh() *Env {
-	e.template = `export {{ .Name }}={{ formatString .Value }}`
+	switch e.Type {
+	case Array:
+		e.template = `export {{ .Name }}=({{ formatArray .Value }})`
+	case String:
+		fallthrough
+	default:
+		e.template = `export {{ .Name }}={{ formatString .Value }}`
+	}
+
 	return e
 }
 

--- a/website/docs/setup/env.mdx
+++ b/website/docs/setup/env.mdx
@@ -23,6 +23,7 @@ env:
 | `delimiter` | `string`  | if you want to join an array of string values (separated by newlines), supports [templating][templates] |
 | `if`        | `string`  | golang [template][go-text-template] conditional statement, see [if][if]                                 |
 | `persist`   | `boolean` | if you want to persist the environment variable into the registry for the current user (Windows only)   |
+| `type`      | `string`  | type to export to, possible values are `string` (default) and `array`                                   |
 
 [templates]: templates.mdx
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).


This PR allows for environment variables to be exported as an Array. A common use case in `zsh` (and I'm sure other shells) is to have an array set up for exclusions or inclusions. Specifically for things like the zsh plugin [YouShouldUse](https://github.com/MichaelAquilina/zsh-you-should-use#disable-hints-for-specific-aliases). These require an array `ENV=("content")` and this was incompatible with the current `formatString`.

I am marking this as a Draft since only `zsh` and `bash` have been implemented directly. I have almost zero knowledge of the other shells Aliae supports and figured if they have functional arrays adding them wouldn't be too difficult for someone who does use them. If not I can go digging around in their docs to get them added.
I am also unsure if `Type` should be a string that would allow future expansion of other types, or if the option should just be `Array` and be a boolean.

| Shell | Array Support | Complete | Tests
|  :---:   |         :---:         |  :---:        | :---: |
| Cmd   | ⛔️					 |  			   |        |
| Bash   | ✅					| ✅			   | ✅|
| Fish    | ✅  <br> (all vars are arrays)     				|  			   |  ✅ |
| Nu      | ✅                    | ✅             |  ✅ |
| Pwsh  |  ✅                   | ✅             |  ✅   |
| Tcsh   | ⛔️ <br> (arrays exist but not for setenv)					| 			   |    |
| Xonsh |✅					| ✅			   | ✅    |
| Zsh   	 |  ✅                   | ✅             | ✅	|
