### PR TITLE
feat: path Force

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -34,17 +34,17 @@ var (
 )
 
 func LoadConfig(configPath string) (*Aliae, error) {
-	configPath = resolveConfigPath(configPath)
+	configPathCache = resolveConfigPath(configPath)
 
-	if strings.HasPrefix(configPath, "http://") || strings.HasPrefix(configPath, "https://") {
-		return getRemoteConfig(configPath)
+	if strings.HasPrefix(configPathCache, "http://") || strings.HasPrefix(configPathCache, "https://") {
+		return getRemoteConfig(configPathCache)
 	}
 
-	if filepath, err := os.Stat(configPath); os.IsNotExist(err) || filepath.IsDir() {
-		return nil, fmt.Errorf("Config file not found: %s", configPath)
+	if filepath, err := os.Stat(configPathCache); os.IsNotExist(err) || filepath.IsDir() {
+		return nil, fmt.Errorf("Config file not found: %s", configPathCache)
 	}
 
-	data, _ := os.ReadFile(configPath)
+	data, _ := os.ReadFile(configPathCache)
 
 	return parseConfig(data)
 }
@@ -72,8 +72,6 @@ func resolveConfigPath(configPath string) string {
 	if len(configPath) == 0 {
 		configPath = path.Join(home(), ".aliae.yaml")
 	}
-
-	configPathCache = configPath
 
 	return configPath
 }

--- a/src/shell/path.go
+++ b/src/shell/path.go
@@ -13,6 +13,7 @@ type Path struct {
 	Value   Template `yaml:"value"`
 	If      If       `yaml:"if"`
 	Persist bool     `yaml:"persist"`
+	Force   bool     `yaml:"force"`
 
 	template string
 }
@@ -55,7 +56,7 @@ func (p *Path) render() string {
 			continue
 		}
 
-		if context.Current.Path.Contains(line) {
+		if context.Current.Path.Contains(line) && !p.Force {
 			continue
 		}
 

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -225,3 +225,137 @@ $env:PATH = '/Users/jan/.tools/bin:' + $env:PATH`,
 		assert.Equal(t, tc.Expected, DotFile.String(), tc.Case)
 	}
 }
+
+func TestPathForce(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Shell    string
+		Path     *Path
+		OS       string
+		Expected string
+	}{
+		{
+			Case:  "Unknown shell",
+			Shell: "FOO",
+			Path:  &Path{Value: "/usr/local/bin"},
+		},
+		{
+			Case:     "PWSH - Force",
+			Shell:    PWSH,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `$env:PATH = '/usr/local/bin:' + $env:PATH`,
+		},
+		{
+			Case:     "PWSH - Not Force",
+			Shell:    PWSH,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "CMD - Force",
+			Shell:    CMD,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `os.setenv("PATH", "/usr/local/bin;" .. os.getenv("PATH"))`,
+		},
+		{
+			Case:     "CMD - Not Force",
+			Shell:    CMD,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "FISH - Force",
+			Shell:    FISH,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `fish_add_path /usr/local/bin`,
+		},
+		{
+			Case:     "FISH - Not Force",
+			Shell:    FISH,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "NU - Force",
+			Shell:    NU,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `$env.PATH = ($env.PATH | prepend "/usr/local/bin")`,
+		},
+		{
+			Case:     "NU - Not Force",
+			Shell:    NU,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:  "NU - Windows Force",
+			Shell: NU,
+			OS:    context.WINDOWS,
+			Path:  &Path{Value: "C:\\bin\nD:\\bin", Force: true},
+			Expected: `$env.Path = ($env.Path | prepend "C:\\bin")
+$env.Path = ($env.Path | prepend "D:\\bin")`,
+		},
+		{
+			Case:     "NU - Windows Not Force",
+			Shell:    NU,
+			OS:       context.WINDOWS,
+			Path:     &Path{Value: "C:\\bin\nD:\\bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "TCSH - Force",
+			Shell:    TCSH,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `set path = ( /usr/local/bin $path );`,
+		},
+		{
+			Case:     "TCSH - Not Force",
+			Shell:    TCSH,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "XONSH - Force",
+			Shell:    XONSH,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `$PATH.add('/usr/local/bin', True, False)`,
+		},
+		{
+			Case:     "XONSH - Not Force",
+			Shell:    XONSH,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "ZSH - Force",
+			Shell:    ZSH,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `export PATH="/usr/local/bin:$PATH"`,
+		},
+		{
+			Case:     "ZSH - Not Force",
+			Shell:    ZSH,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+		{
+			Case:     "ZSH - Windows Force",
+			Shell:    ZSH,
+			OS:       context.WINDOWS,
+			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Expected: `export PATH="/usr/local/bin;$PATH"`,
+		},
+		{
+			Case:     "ZSH - Windows Not Force",
+			Shell:    ZSH,
+			OS:       context.WINDOWS,
+			Path:     &Path{Value: "/usr/local/bin"},
+			Expected: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		context.Current = &context.Runtime{Shell: tc.Shell, Home: "/Users/jan", OS: tc.OS, Path: &context.Path{"/usr/local/bin", "C:\\bin", "D:\\bin"}}
+		assert.Equal(t, tc.Expected, tc.Path.string(), tc.Case)
+	}
+}

--- a/website/docs/setup/path.mdx
+++ b/website/docs/setup/path.mdx
@@ -18,6 +18,7 @@ path:
   - value: |
       {{ .Home }}/go/bin/
       {{ env "VOLTA_HOME" }}/bin
+    force: true
 ```
 
 ### Path
@@ -27,6 +28,7 @@ path:
 | `value`   | `string`  | the path entires you want to add, separated by a newline. Supports [templating][templates]  |
 | `if`      | `string`  | golang [template][go-text-template] conditional statement, see [if][if]                     |
 | `persist` | `boolean` | if you want to persist the path entry into the registry for the current user (Windows only) |
+| `force`   | `boolean` | if you want to always export the path even if it already exists in your current shell       |
 
 [templates]: templates.mdx
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

## Feature:
Allows paths to `Always` be exported, even if they exist in the current path

### Reasoning:
I use the ZSH plugin manager [zinit](https://github.com/zdharma-continuum/zinit) along with [z-a-eval annex](https://github.com/vladdoster/z-a-eval), this allows the output of `aliae init zsh` to be cached during ZSH startup so that it does not need to run every startup.

### Issue:
When running `zinit recache` (from the eval annex) Aliae detects my path as already having the paths I'm trying to export in it, thus not adding them to the cached output. This ends up in a scenario where I need to `recache` open a new shell which now does not have the paths exported, `recache` again, and _then_ future shells will have the proper paths set.

### Resolution:
A simple `always: true` flag to the path declaration will force it to print the path export command even if it already exists in the path.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
