### PR TITLE
feat: aliae performance improvement for Windows cmd clink integration

### DIFF
--- a/src/shell/aliae.go
+++ b/src/shell/aliae.go
@@ -93,6 +93,10 @@ func (a Aliae) Render() {
 			DotFile.WriteString("\n\n")
 		}
 
+		if first && context.Current.Shell == CMD {
+			DotFile.WriteString(cmdAliasPre())
+		}
+
 		if !first {
 			DotFile.WriteString("\n")
 		}
@@ -100,5 +104,9 @@ func (a Aliae) Render() {
 		DotFile.WriteString(script)
 
 		first = false
+	}
+
+	if context.Current.Shell == CMD {
+		DotFile.WriteString(cmdAliasPost())
 	}
 }

--- a/src/shell/aliae_test.go
+++ b/src/shell/aliae_test.go
@@ -20,10 +20,9 @@ func TestAliasCommand(t *testing.T) {
 			Expected: "Set-Alias -Name foo -Value bar",
 		},
 		{
-			Case:  "CMD",
-			Shell: CMD,
-			Expected: `local p = assert(io.popen("doskey foo=bar"))
-p:close()`,
+			Case:     "CMD",
+			Shell:    CMD,
+			Expected: "macrofile:write(\"foo=bar\", \"\\n\")",
 		},
 		{
 			Case:     "FISH",

--- a/src/shell/cmd.go
+++ b/src/shell/cmd.go
@@ -8,8 +8,7 @@ const (
 
 func (a *Alias) cmd() *Alias {
 	if a.Type == Command {
-		a.template = `local p = assert(io.popen("doskey {{ .Name }}={{ escapeString .Value }}"))
-p:close()`
+		a.template = "macrofile:write(\"{{ .Name }}={{ escapeString .Value }}\", \"\\n\")"
 	}
 
 	return a
@@ -31,4 +30,19 @@ func (e *Env) cmd() *Env {
 func (p *Path) cmd() *Path {
 	p.template = `os.setenv("PATH", "{{ escapeString .Value }};" .. os.getenv("PATH"))`
 	return p
+}
+
+func cmdAliasPre() string {
+	return `
+local filename  = os.tmpname()
+local macrofile = io.open(filename, "w+")
+`
+}
+
+func cmdAliasPost() string {
+	return `
+macrofile:close()
+local _ = io.popen(string.format("doskey /macrofile=%s", filename)):close()
+os.remove(filename)
+`
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Performance Issue Defined

The Lua script generated by Aliae uses multiple `io.popen` calls executed in serial. Each `io.popen` call takes 20ms when Clink is injected and 50ms when Clink is configured for autorun.

```
local p = assert(io.popen("doskey tf=terraform $*"))
p:close()
local p = assert(io.popen("doskey tfa=terraform apply $*"))
p:close()
local p = assert(io.popen("doskey tfd=terraform destroy $*"))
p:close()
local p = assert(io.popen("doskey tfv=terraform validate $*"))
p:close()
local p = assert(io.popen("doskey tfi=terraform init $*"))
p:close()
```

As such, the more aliases you configure, the longer the delay when launching CMD with Clink. With 70 aliases, the Lua script takes 4-7 seconds to execute before the prompt is ready for input.

### Proposed Solution

I propose the use of a Doskey macrofile, which will require only one `io.popen` call, greatly improving the performance with Clink on Windows to a near-instantaneous start time for `cmd.exe`.

The resulting Aliae syntax generated for clink looks like:

```
local filename  = os.tmpname()
local macrofile = io.open(filename, "w+")
macrofile:write("tf=terraform $*", "\n")
macrofile:write("tfa=terraform apply $*", "\n")
macrofile:write("tfd=terraform destroy $*", "\n")
macrofile:write("tfv=terraform validate $*", "\n")
macrofile:write("tfi=terraform init $*", "\n")
macrofile:close()
local _ = io.popen(string.format("doskey /macrofile=%s", filename)):close()
os.remove(filename)
```

### Side Effect / Breaking Change

Aliases making use of an ampersand (&amp;) need to be specified differently when using a macrofile versus directly on the command line.  As such, the yaml configuration for aliases using &amp; would require updating.

Alias definitions in current state:
 
```
alias:
  - name: git-lazy
    value: >- 
      git commit -m "." ^&^& git push
    if: match .Shell "cmd"
```

Would need to be updated after this code change:

```
alias:
  - name: git-lazy
    value: >- 
      git commit -m "." && git push
    if: match .Shell "cmd" "zsh" "bash"
```

Another benefit of the change to a macrofile allows for greater support of cross-platform aliases -- case in point the git alias above requires different syntax for windows in current state, but in the proposed future state, one alias serves many platforms.  

A workaround to support the transition could involve simple string replacement of `^&` with `&` to make the change non-breaking.  I'm not a fan of hidden string manipulation, so I did not implement it in this PR; however, it could be an effective migration strategy to consider.

### Final Thoughts

I believe the performance improvement is worth the risk of a small, but easy to fix, breaking change.