### PR TITLE
docs: add schema.json

### DIFF
--- a/resources/aliae.schema.json
+++ b/resources/aliae.schema.json
@@ -1,0 +1,123 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "alias": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "the alias name"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "the command(s) you want to execute, supports [templating](https://aliae.dev/docs/setup/templates)"
+                    },
+                    "type": {
+                        "type": "string",
+                        "oneOf": [
+                            {
+                                "const": "command",
+                                "description": "a regular alias, value is a one-liner (default)"
+                            },
+                            {
+                                "const": "function",
+                                "description": "a code block to be placed inside a function"
+                            },
+                            {
+                                "const": "git",
+                                "description": "a git alias definition"
+                            }
+                        ]
+                    },
+                    "if": {
+                        "type": "string",
+                        "description": "golang [template](https://golang.org/pkg/text/template/) conditional statement, see [if](https://aliae.dev/docs/setup/if)"
+                    }
+                },
+                "required": [
+                    "name",
+                    "value"
+                ]
+            }
+        },
+        "env": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "the variable name"
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "the variable value, supports [templating](https://aliae.dev/docs/setup/templates)"
+                    },
+                    "delimiter": {
+                        "type": "string",
+                        "description": "if you want to join an array of string values (separated by newlines), supports [templating](https://aliae.dev/docs/setup/templates)"
+                    },
+                    "if": {
+                        "type": "string",
+                        "description": "golang template conditional statement, see if"
+                    },
+                    "persist": {
+                        "type": "boolean",
+                        "description": "if you want to persist the environment variable into the registry for the current user (Windows only)"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "type to export to",
+                        "enum": [
+                            "string",
+                            "array"
+                        ]
+                    }
+                }
+            },
+            "path": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "description": "the path entires you want to add, separated by a newline. Supports [templating](https://aliae.dev/docs/setup/templates)"
+                        },
+                        "if": {
+                            "type": "string",
+                            "description": "golang [template](https://golang.org/pkg/text/template/) conditional statement, see [if](https://aliae.dev/docs/setup/if)"
+                        },
+                        "persist": {
+                            "type": "boolean",
+                            "description": "if you want to persist the environment variable into the registry for the current user (Windows only)"
+                        },
+                        "force": {
+                            "type": "boolean",
+                            "description": "if you want to always export the path even if it already exists in your current shell"
+                        }
+                    }
+                }
+            },
+            "script": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "type": "string",
+                            "description": "the script you want to load. Supports [templating](https://aliae.dev/docs/setup/templates)"
+                        },
+                        "if": {
+                            "type": "string",
+                            "description": "golang [template](https://golang.org/pkg/text/template/) conditional statement, see [if](https://aliae.dev/docs/setup/if)"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

# Just a Nice-To-Have

recently found out [how to use json schema in yaml](https://developers.redhat.com/blog/2020/11/25/how-to-configure-yaml-schema-to-make-editing-files-easier#schema_association_without_a_file_name_pattern) an thought aliae could benefit.

i created a json schema based on the [docs](https://aliae.dev/docs/setup/configuration), so far from my testing intellisense works fine. 

![image](https://github.com/user-attachments/assets/49a02c48-fce3-4cb1-b1da-8551806f87b4)
![image](https://github.com/user-attachments/assets/1f2ba147-609e-4643-9396-685d31a7b0c0)

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
