### PR TITLE
docs: add symbolic-links page to sidebar & capitalize script in sidebar

### DIFF
--- a/website/docs/setup/script.mdx
+++ b/website/docs/setup/script.mdx
@@ -1,7 +1,7 @@
 ---
 id: script
 title: Script
-sidebar_label: ✍🏽 script
+sidebar_label: ✍🏽 Script
 ---
 
 Specify the same script cross shell.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -21,10 +21,11 @@ module.exports = {
         "setup/alias",
         "setup/env",
         "setup/path",
+        "setup/link",
         "setup/script",
         "setup/if",
         "setup/templates",
-        "setup/include"
+        "setup/include",
       ],
     },
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [-] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Changes

- Add Symbolic Link page to the docs sidebar - somehow we missed that in #192
- Capitalize "Script" in sidebar to match the other pages