### PR TITLE
Fix string quoting in PowerShell and address linting problems

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ can be a good starting point.
 
 1. Ensure any dependencies or build artifacts are removed/ignored before creating a commit.
 2. Commits follow the [conventional commits][cc] guidelines.
-(You can [look up the supported *types*][cc-types] along with an explanation [here][cc-types])
+(You can [look up the supported *types*][cc-types] along with an explanation [in the documentation][cc-types])
 3. Update the documentation with details of changes to the functionality, this includes new segments
    or core functionality.
 4. Pull Requests are merged once all checks pass and a project maintainer has approved it.

--- a/src/shell/aliae_test.go
+++ b/src/shell/aliae_test.go
@@ -17,7 +17,7 @@ func TestAliasCommand(t *testing.T) {
 		{
 			Case:     "PWSH",
 			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar",
+			Expected: `Set-Alias -Name foo -Value "bar"`,
 		},
 		{
 			Case:     "CMD",

--- a/src/shell/git.go
+++ b/src/shell/git.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	context_ "context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -62,8 +63,7 @@ func (a *Alias) getGitAliasOutput() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	cmd := exec.Command(path, "config", "--get-regexp", "^alias\\.")
+	cmd := exec.CommandContext(context_.Background(), path, "config", "--get-regexp", "^alias\\.")
 	// when no aliae have been set, it causes git to panic
 	raw, _ := cmd.Output()
 	return string(raw), nil

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -25,27 +25,27 @@ func TestPath(t *testing.T) {
 			Case:     "PWSH - single item",
 			Shell:    PWSH,
 			Path:     &Path{Value: "/usr/local/bin"},
-			Expected: `$env:PATH = '/usr/local/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:     "PWSH - single item with template",
 			Shell:    PWSH,
 			Path:     &Path{Value: "{{ .Home }}/.tools/bin"},
-			Expected: `$env:PATH = '/Users/jan/.tools/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:  "PWSH - single item with blank line",
 			Shell: PWSH,
 			Path:  &Path{Value: "/usr/local/bin\n\n/usr/bin"},
-			Expected: `$env:PATH = '/usr/local/bin:' + $env:PATH
-$env:PATH = '/usr/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH
+$env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:  "PWSH - multiple items",
 			Shell: PWSH,
 			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
-			Expected: `$env:PATH = '/usr/local/bin:' + $env:PATH
-$env:PATH = '/usr/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH
+$env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:     "CMD - single item",
@@ -180,7 +180,7 @@ func TestPathRender(t *testing.T) {
 				&Path{Value: "/usr/bin", If: `eq .Shell "pwsh"`},
 			},
 			Shell:    PWSH,
-			Expected: `$env:PATH = '/usr/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case: "PWSH - 1 PATH definition",
@@ -188,7 +188,7 @@ func TestPathRender(t *testing.T) {
 				&Path{Value: "/usr/bin"},
 			},
 			Shell:    PWSH,
-			Expected: `$env:PATH = '/usr/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case: "PWSH - Single PATH, non empty",
@@ -199,7 +199,7 @@ func TestPathRender(t *testing.T) {
 			NonEmptyScript: true,
 			Expected: `foo
 
-$env:PATH = '/usr/bin:' + $env:PATH`,
+$env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case: "PWSH - 2 PATH definitions",
@@ -208,8 +208,8 @@ $env:PATH = '/usr/bin:' + $env:PATH`,
 				&Path{Value: "/Users/jan/.tools/bin"},
 			},
 			Shell: PWSH,
-			Expected: `$env:PATH = '/usr/bin:' + $env:PATH
-$env:PATH = '/Users/jan/.tools/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH
+$env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case: "PWSH - 2 PATH definitions with conditional",
@@ -218,7 +218,7 @@ $env:PATH = '/Users/jan/.tools/bin:' + $env:PATH`,
 				&Path{Value: "/Users/jan/.tools/bin"},
 			},
 			Shell:    PWSH,
-			Expected: `$env:PATH = '/Users/jan/.tools/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
 		},
 	}
 
@@ -250,7 +250,7 @@ func TestPathForce(t *testing.T) {
 			Case:     "PWSH - Force",
 			Shell:    PWSH,
 			Path:     &Path{Value: "/usr/local/bin", Force: true},
-			Expected: `$env:PATH = '/usr/local/bin:' + $env:PATH`,
+			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:     "PWSH - Not Force",

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -41,7 +41,7 @@ func (a *Alias) pwsh() *Alias {
 
 	switch a.Type { //nolint:exhaustive
 	case Command:
-		a.template = `Set-Alias -Name {{ .Name }} -Value {{ .Value }}{{ if .Description }} -Description '{{ .Description }}'{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ .Scope }}{{ end }}` //nolint: lll
+		a.template = `Set-Alias -Name {{ .Name }} -Value {{ formatString .Value }}{{ if .Description }} -Description {{ formatString .Description }}{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ formatString .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ formatString .Scope }}{{ end }}` //nolint: lll
 	case Function:
 		a.template = `function {{ .Name }}() {
     {{ .Value }}
@@ -79,7 +79,7 @@ func (l *Link) pwsh() *Link {
 }
 
 func (p *Path) pwsh() *Path {
-	template := fmt.Sprintf(`$env:PATH = '{{ .Value }}%s' + $env:PATH`, context.PathDelimiter())
+	template := fmt.Sprintf(`$env:PATH = {{ formatString .Value }} + '%s' + $env:PATH`, context.PathDelimiter())
 	p.template = template
 	return p
 }

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"testing"
 
+	"github.com/jandedobbeleer/aliae/src/context"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,19 +11,19 @@ func TestPowerShellCommandAlias(t *testing.T) {
 	cases := []struct {
 		Alias    *Alias
 		Case     string
-		Shell    string
 		Expected string
 	}{
 		{
 			Case:     "PWSH",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar",
-			Alias:    &Alias{Name: "foo", Value: "bar"},
+			Expected: `Set-Alias -Name foo -Value "bar"`,
+			Alias: &Alias{
+				Name:  "foo",
+				Value: "bar",
+			},
 		},
 		{
 			Case:     "PWSH - Description",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Description 'This is a description'",
+			Expected: `Set-Alias -Name foo -Value "bar" -Description "This is a description"`,
 			Alias: &Alias{
 				Name:        "foo",
 				Value:       "bar",
@@ -31,8 +32,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Force",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Force",
+			Expected: `Set-Alias -Name foo -Value "bar" -Force`,
 			Alias: &Alias{
 				Name:  "foo",
 				Value: "bar",
@@ -41,8 +41,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Option",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Option AllScope",
+			Expected: `Set-Alias -Name foo -Value "bar" -Option "AllScope"`,
 			Alias: &Alias{
 				Name:   "foo",
 				Value:  "bar",
@@ -51,8 +50,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Scope",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Scope Global",
+			Expected: `Set-Alias -Name foo -Value "bar" -Scope "Global"`,
 			Alias: &Alias{
 				Name:  "foo",
 				Value: "bar",
@@ -61,8 +59,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Description && Force",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Description 'This is a description' -Force",
+			Expected: `Set-Alias -Name foo -Value "bar" -Description "This is a description" -Force`,
 			Alias: &Alias{
 				Name:        "foo",
 				Value:       "bar",
@@ -72,8 +69,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Description && Force && Scope",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Description 'This is a description' -Force -Scope Global",
+			Expected: `Set-Alias -Name foo -Value "bar" -Description "This is a description" -Force -Scope "Global"`,
 			Alias: &Alias{
 				Name:        "foo",
 				Value:       "bar",
@@ -84,8 +80,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 		},
 		{
 			Case:     "PWSH - Description && Force && Scope && Option",
-			Shell:    PWSH,
-			Expected: "Set-Alias -Name foo -Value bar -Description 'This is a description' -Force -Option AllScope -Scope Global",
+			Expected: `Set-Alias -Name foo -Value "bar" -Description "This is a description" -Force -Option "AllScope" -Scope "Global"`,
 			Alias: &Alias{
 				Name:        "foo",
 				Value:       "bar",
@@ -98,6 +93,7 @@ func TestPowerShellCommandAlias(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		context.Current = &context.Runtime{Shell: PWSH}
 		tc.Alias.Type = Command
 		assert.Equal(t, tc.Expected, tc.Alias.pwsh().render(), tc.Case)
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

To improve robustness, I think we can extract the shell-specific quoting logic in Oh My Posh and reuse it in Aliae.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary