### PR TITLE
docs: remove references to scoop from the website

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -14,7 +14,6 @@ import TabItem from "@theme/TabItem";
   groupId="install"
   values={[
     { label: 'winget', value: 'winget', },
-    { label: 'scoop', value: 'scoop', },
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -24,15 +23,6 @@ Open a PowerShell prompt and run the following command:
 
 ```powershell
 winget install JanDeDobbeleer.Aliae -s winget
-```
-
-</TabItem>
-<TabItem value="scoop">
-
-Open a PowerShell prompt and run the following command:
-
-```powershell
-scoop install https://github.com/JanDeDobbeleer/aliae/releases/latest/download/aliae.json
 ```
 
 </TabItem>
@@ -54,7 +44,6 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
   groupId="install"
   values={[
     { label: 'winget', value: 'winget', },
-    { label: 'scoop', value: 'scoop', },
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -64,15 +53,6 @@ Open a PowerShell prompt and run the following command:
 
 ```powershell
 winget upgrade JanDeDobbeleer.Aliae -s winget
-```
-
-</TabItem>
-<TabItem value="scoop">
-
-Open a PowerShell prompt and run the following command:
-
-```powershell
-scoop update Aliae
 ```
 
 </TabItem>


### PR DESCRIPTION
Scoop is no longer supported (see #301), so it has been removed from the website/documentation.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] (n/a) Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://aliae.dev/docs/contributing/git) to help you out.
aliae advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
