### PR TITLE
fix: prevent panic when calling get cmd without args

### DIFF
--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -21,6 +21,10 @@ This command is used to get the value of the following variables:
 	},
 	Args: cobra.OnlyValidArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			return
+		}
 
 		switch args[0] {
 		case "shell":


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

### Info

I noticed that running `aliae get` without any arguments results in a panic due to indexing into an empty arg slice. I've added a check to prevent this.