### PR TITLE
feat: allow non-existent !include_dirs

### DIFF
--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -136,8 +137,14 @@ func indent(data []byte) []byte {
 
 func readDir(dir string) ([]byte, error) {
 	files, err := os.ReadDir(dir)
-	if err != nil {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// If the directory does not exist, treat it as empty
+		return []byte{}, nil
+	case err != nil:
 		return []byte{}, err
+	case len(files) == 0:
+		return []byte{}, nil
 	}
 
 	var configData []byte

--- a/src/config/unmarshal_test.go
+++ b/src/config/unmarshal_test.go
@@ -34,8 +34,9 @@ func TestReadDir(t *testing.T) {
 	})
 
 	t.Run("NonExistentDir", func(t *testing.T) {
-		_, err := readDir("path/to/nonexistent/dir")
-		assert.Error(t, err)
+		content, err := readDir("path/to/nonexistent/dir")
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{}, content)
 	})
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

## Changes

This change alters the behaviour of the `!include_dir` directive to not error if the specified directory does not exist. The reasoning for this is to support the use case where you know you want to have a multi-folder layout for your configs, but do not currently have config files for everything. While yes, you _could_ simply just not reference non-existent things in the main config file, it's a small convenience to be able to define the structure upfront and then create the subfolders and subconfigs as and when they are needed.