### PR TITLE
feat: allow non-existent !include_dirs

### DIFF
--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -228,8 +229,14 @@ func indent(data []byte) []byte {
 
 func readDir(dir string) ([]byte, error) {
 	files, err := os.ReadDir(dir)
-	if err != nil {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// If the directory does not exist, treat it as empty
+		return []byte{}, nil
+	case err != nil:
 		return []byte{}, err
+	case len(files) == 0:
+		return []byte{}, nil
 	}
 
 	var configData []byte

--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -235,8 +235,6 @@ func readDir(dir string) ([]byte, error) {
 		return []byte{}, nil
 	case err != nil:
 		return []byte{}, err
-	case len(files) == 0:
-		return []byte{}, nil
 	}
 
 	var configData []byte

--- a/src/config/unmarshal_test.go
+++ b/src/config/unmarshal_test.go
@@ -36,8 +36,9 @@ func TestReadDir(t *testing.T) {
 	})
 
 	t.Run("NonExistentDir", func(t *testing.T) {
-		_, err := readDir("path/to/nonexistent/dir")
-		assert.Error(t, err)
+		content, err := readDir("path/to/nonexistent/dir")
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{}, content)
 	})
 }
 

--- a/website/docs/setup/include.mdx
+++ b/website/docs/setup/include.mdx
@@ -24,6 +24,9 @@ The `!include` and `!include_dir` yaml tags allow you to include a single file o
 This allows for clean organization of aliae, envs, and all other things handled by Aliae.
 File/Directory paths support [templating][templates].
 
+If the directory given to `!include_dir` does not exist, it is treated as empty rather than raising an
+error. This lets you define a multi-folder config layout upfront and add the subfolders as you need them.
+
 ## Inline Include
 
 If you want to have a more fine grained control over the included file, you can use the `!include` tag inline in combination


### PR DESCRIPTION
## Summary
Supersedes #310 (rebased onto current `main`, review fixes applied — squash-mergeable as one PR).

- `!include_dir` no longer errors when the target directory doesn't exist; it's treated as empty. Lets you define a multi-folder config layout before all subfolders exist. (original change from #310, credit @darkliquid)
- Drop the redundant `len(files) == 0` branch in `readDir` — the existing empty-loop path already returns the same result.
- Document the new missing-directory tolerance in the include docs.

## Test plan
- [x] `go test ./config/...` passes (includes updated `NonExistentDir` case)
- [x] `gofmt -l .` clean
- [x] `go build ./...` succeeds

Co-Authored-By: darkliquid <darkliquid@darkliquid.co.uk>