### PR TITLE
feat: init --tty-only and devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.1"
+      "version": "1.26.5"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20.9.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "aliae",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.24.1"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20.9.0",
+      "nodeGypDependencies": true,
+      "npmVersion": "10.1.0"
+    }
+  },
+  "workspaceFolder": "/workspaces/aliae",
+  "postCreateCommand": "bash -lc 'cd src && go mod download && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest && cd ../website && npm ci'",
+  "forwardPorts": [
+    3000
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.Go",
+        "ms-vscode.vscode-typescript-next",
+        "ms-azuretools.vscode-docker",
+        "hbenl.vscode-test-explorer"
+      ],
+      "settings": {
+        "go.toolsManagement.autoUpdate": true,
+        "go.useLanguageServer": true,
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -2,17 +2,20 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	cfg "github.com/jandedobbeleer/aliae/src/config"
 )
 
 var (
 	printOutput bool
+	ttyOnly     bool
 
 	initCmd = &cobra.Command{
-		Use:   "init [bash|zsh|fish|pwsh|powershell|cmd|nu|tcsh|xonsh] --config ~/.aliae.yaml",
+		Use:   "init [bash|zsh|fish|pwsh|powershell|cmd|nu|tcsh|xonsh] --tty-only --config ~/.aliae.yaml",
 		Short: "Initialize your shell and config",
 		Long: `Initialize your shell and config.
 
@@ -41,11 +44,15 @@ See the documentation to initialize your shell: https://aliae.dev/docs/setup/she
 
 func init() {
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
+	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", false, "only print if output is a TTY")
 	_ = initCmd.MarkPersistentFlagRequired("config")
 	RootCmd.AddCommand(initCmd)
 }
 
 func runInit(shellName string) {
+	if ttyOnly && !term.IsTerminal(int(os.Stdout.Fd())) {
+		return
+	}
 	init := cfg.Init(config, shellName, printOutput)
 	fmt.Print(init)
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/term v0.45.0
 )
 
 require (

--- a/src/go.sum
+++ b/src/go.sum
@@ -31,6 +31,8 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary
Supersedes #311 (rebased onto current main, squashed into one commit to preserve @trajano's authorship, plus a follow-up fix).

- `init --tty-only`: only print the shell init script when stdout is a TTY
- devcontainer: Go + Node toolchains, lint/test tool install, website `npm ci`, test explorer extension
- fix: devcontainer's Go feature was pinned to `1.24.1`, below `go.mod`'s `go 1.25.0` and CI's pinned `1.26.5` — bumped to `1.26.5`
- fix: `init --tty-only` used `golang.org/x/term` without declaring it in `go.mod`/`go.sum` — added via `go get`/`go mod tidy` (folded into the first commit so it builds standalone)

## Testing
- `go build ./...` passes
- Validated `.devcontainer/devcontainer.json` is still valid JSON
- Devcontainer not rebuilt (no local container runtime available here)

Closes #311