### PR TITLE
feat(config): extract wrapped sections from included files

### DIFF
--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
 	"github.com/jandedobbeleer/aliae/src/shell"
 )
 
@@ -22,10 +24,16 @@ type Aliae struct {
 	Links   shell.Links   `yaml:"link"`
 }
 
-type FuncMap []StringFunc
-type StringFunc struct {
-	F    func(string) ([]byte, error)
-	Name []byte
+// sectionKeys are the top-level Aliae document keys (config.go's Aliae struct tags)
+// that an included file may itself be wrapped in, e.g. a file combining alias/env/script
+// sections that gets included separately at each section's own position.
+var sectionKeys = map[string]bool{
+	"alias":  true,
+	"env":    true,
+	"path":   true,
+	"cdpath": true,
+	"script": true,
+	"link":   true,
 }
 
 func aliaeUnmarshaler(a *Aliae, b []byte) error {
@@ -48,34 +56,28 @@ func includeUnmarshaler(b []byte) ([]byte, error) {
 
 	s := bytes.Split(b, newline)
 
-	includeFuncMap := FuncMap{
-		{
-			Name: []byte("!include_dir"),
-			F:    readDir,
-		},
-		{
-			Name: []byte("!include"),
-			F:    os.ReadFile,
-		},
+	tagNames := [][]byte{
+		[]byte("!include_dir"),
+		[]byte("!include"),
 	}
 
 	for i, line := range s {
-		for _, f := range includeFuncMap {
-			if !bytes.Contains(line, f.Name) {
+		for _, name := range tagNames {
+			if !bytes.Contains(line, name) {
 				continue
 			}
 
 			parts := bytes.Fields(line)
 			if len(parts) < 3 {
-				return nil, fmt.Errorf("invalid %s directive: \n%s", f.Name, line)
+				return nil, fmt.Errorf("invalid %s directive: \n%s", name, line)
 			}
 
-			tagIdx := bytes.Index(line, f.Name)
-			argument := bytes.TrimSpace(line[tagIdx+len(f.Name):])
+			tagIdx := bytes.Index(line, name)
+			argument := bytes.TrimSpace(line[tagIdx+len(name):])
 
 			content, ok := unquoteArgument(argument)
 			if !ok {
-				return nil, fmt.Errorf("invalid %s directive: \n%s", f.Name, line)
+				return nil, fmt.Errorf("invalid %s directive: \n%s", name, line)
 			}
 
 			folder, condition, hasCondition := splitIncludeCondition(content)
@@ -90,9 +92,34 @@ func includeUnmarshaler(b []byte) ([]byte, error) {
 				return nil, err
 			}
 
-			data, err := f.F(path)
+			destKey := sectionDestKey(parts[0])
+			isDir := string(name) == "!include_dir"
+
+			var data []byte
+			if isDir {
+				data, err = readDir(path, destKey)
+			} else {
+				data, err = os.ReadFile(path)
+			}
+
 			if err != nil {
 				return nil, err
+			}
+
+			if !isDir && destKey != "" {
+				extracted, wrapped, extractErr := extractSection(data, destKey)
+				if extractErr != nil {
+					return nil, extractErr
+				}
+
+				if wrapped && len(extracted) == 0 {
+					s[i] = skippedIncludeLine(parts[0])
+					break
+				}
+
+				if wrapped {
+					data = extracted
+				}
 			}
 
 			splitted := bytes.Split(data, newline)
@@ -227,7 +254,12 @@ func indent(data []byte) []byte {
 	return newData
 }
 
-func readDir(dir string) ([]byte, error) {
+// readDir reads every YAML file in dir and joins their content with a blank line.
+// When destKey is one of sectionKeys, each file's content is first passed through
+// extractSection: a file wrapped in that section contributes only that section
+// (or nothing, if it doesn't carry that section); a bare-list file (today's shape)
+// is used unchanged.
+func readDir(dir, destKey string) ([]byte, error) {
 	files, err := os.ReadDir(dir)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
@@ -237,9 +269,9 @@ func readDir(dir string) ([]byte, error) {
 		return []byte{}, err
 	}
 
-	var configData []byte
+	var chunks [][]byte
 
-	for i, file := range files {
+	for _, file := range files {
 		if !isYAMLExtension(file.Name()) {
 			continue
 		}
@@ -250,14 +282,88 @@ func readDir(dir string) ([]byte, error) {
 			continue
 		}
 
-		configData = append(configData, data...)
+		if destKey != "" {
+			extracted, wrapped, err := extractSection(data, destKey)
+			if err != nil {
+				return nil, err
+			}
 
-		if i != len(files)-1 {
-			configData = append(configData, []byte("\n")...)
+			if wrapped {
+				data = extracted
+			}
+		}
+
+		if len(data) == 0 {
+			continue
+		}
+
+		chunks = append(chunks, data)
+	}
+
+	return bytes.Join(chunks, []byte("\n")), nil
+}
+
+// sectionDestKey returns the top-level Aliae section (see sectionKeys) an include
+// directive targets directly, e.g. "alias" for `alias: !include ...`. It returns ""
+// for a list-item include (`- !include ...`, no ancestor key tracked) or a key that
+// isn't a recognized section — signaling that section extraction must not run.
+func sectionDestKey(key []byte) string {
+	trimmed := strings.TrimSuffix(string(key), ":")
+	if !sectionKeys[trimmed] {
+		return ""
+	}
+
+	return trimmed
+}
+
+// extractSection inspects an included file's content for a top-level mapping
+// carrying one or more sectionKeys, e.g. a file combining alias/env/script into one
+// document. When such a mapping is found, wrapped is true and extracted holds the
+// raw source text of destKey's value (empty when the file doesn't carry that
+// section), so nested !include tags, block scalars, and Go-template syntax within
+// it survive untouched for the next unmarshal pass. wrapped is false when the
+// content isn't shaped this way (e.g. a bare list), signaling the caller to use the
+// original content unchanged.
+func extractSection(data []byte, destKey string) (extracted []byte, wrapped bool, err error) {
+	file, err := parser.ParseBytes(data, 0)
+	if err != nil {
+		// not valid enough to inspect; let the normal decode path surface the error
+		return nil, false, nil
+	}
+
+	if len(file.Docs) == 0 || file.Docs[0].Body == nil {
+		return nil, false, nil
+	}
+
+	if len(file.Docs) > 1 {
+		return nil, false, errors.New("included file with multiple YAML documents is not supported")
+	}
+
+	mapping, ok := file.Docs[0].Body.(*ast.MappingNode)
+	if !ok {
+		return nil, false, nil
+	}
+
+	var found *ast.MappingValueNode
+
+	for _, value := range mapping.Values {
+		key := strings.Trim(value.Key.String(), `"'`)
+		if !sectionKeys[key] {
+			continue
+		}
+
+		wrapped = true
+
+		if key == destKey {
+			found = value
 		}
 	}
 
-	return configData, nil
+	if !wrapped || found == nil {
+		return nil, wrapped, nil
+	}
+
+	return []byte(found.Value.String()), true, nil
 }
 
 func validatePath(path string) (string, error) {

--- a/src/config/unmarshal_test.go
+++ b/src/config/unmarshal_test.go
@@ -30,13 +30,13 @@ func TestReadDir(t *testing.T) {
 	t.Run("ValidDir", func(t *testing.T) {
 		testDirPath := filepath.Join("test", "files")
 		absPath, _ := filepath.Abs(testDirPath)
-		content, err := readDir(absPath)
+		content, err := readDir(absPath, "")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("it exists\nit exists2"), content)
 	})
 
 	t.Run("NonExistentDir", func(t *testing.T) {
-		content, err := readDir("path/to/nonexistent/dir")
+		content, err := readDir("path/to/nonexistent/dir", "")
 		assert.NoError(t, err)
 		assert.Equal(t, []byte{}, content)
 	})
@@ -137,6 +137,142 @@ func TestIncludeUnmarshalerCondition(t *testing.T) {
 		var a Aliae
 		err := aliaeUnmarshaler(&a, []byte(input))
 		assert.NoError(t, err)
+	})
+}
+
+func TestExtractSection(t *testing.T) {
+	t.Run("bare list is not wrapped", func(t *testing.T) {
+		extracted, wrapped, err := extractSection([]byte("- name: test\n  value: test"), "alias")
+		assert.NoError(t, err)
+		assert.False(t, wrapped)
+		assert.Nil(t, extracted)
+	})
+
+	t.Run("empty file is not wrapped", func(t *testing.T) {
+		extracted, wrapped, err := extractSection([]byte(""), "alias")
+		assert.NoError(t, err)
+		assert.False(t, wrapped)
+		assert.Nil(t, extracted)
+	})
+
+	t.Run("map without any recognized section key is not wrapped", func(t *testing.T) {
+		extracted, wrapped, err := extractSection([]byte("foo: bar"), "alias")
+		assert.NoError(t, err)
+		assert.False(t, wrapped)
+		assert.Nil(t, extracted)
+	})
+
+	t.Run("wrapped file carrying the requested section returns just that section", func(t *testing.T) {
+		input := "alias:\n  - name: test\n    value: test\nenv:\n  - name: FOO\n    value: bar\n"
+		extracted, wrapped, err := extractSection([]byte(input), "alias")
+		assert.NoError(t, err)
+		assert.True(t, wrapped)
+		assert.Contains(t, string(extracted), "name: test")
+		assert.NotContains(t, string(extracted), "FOO")
+	})
+
+	t.Run("wrapped file missing the requested section is wrapped with no content", func(t *testing.T) {
+		input := "env:\n  - name: FOO\n    value: bar\n"
+		extracted, wrapped, err := extractSection([]byte(input), "alias")
+		assert.NoError(t, err)
+		assert.True(t, wrapped)
+		assert.Empty(t, extracted)
+	})
+
+	t.Run("nested !include tag inside the extracted section survives untouched", func(t *testing.T) {
+		input := "alias:\n  - !include \"nested.yaml\"\n  - name: g\n    value: git\n"
+		extracted, wrapped, err := extractSection([]byte(input), "alias")
+		assert.NoError(t, err)
+		assert.True(t, wrapped)
+		assert.Contains(t, string(extracted), `!include "nested.yaml"`)
+	})
+
+	t.Run("multiple YAML documents are rejected", func(t *testing.T) {
+		input := "alias:\n  - name: a\n    value: a\n---\nenv:\n  - name: B\n    value: b\n"
+		_, _, err := extractSection([]byte(input), "alias")
+		assert.Error(t, err)
+	})
+}
+
+func TestIncludeUnmarshalerSection(t *testing.T) {
+	t.Run("include - wrapped file contributes only the destination section", func(t *testing.T) {
+		dir := t.TempDir()
+		combined := filepath.Join(dir, "combined.yaml")
+		assert.NoError(t, os.WriteFile(combined, []byte("alias:\n  - name: a\n    value: a\nenv:\n  - name: B\n    value: b\n"), 0o644))
+
+		input := fmt.Sprintf(`alias: !include "%s"`, combined)
+		result, err := includeUnmarshaler([]byte(input))
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "name: a")
+		assert.NotContains(t, string(result), "name: B")
+	})
+
+	t.Run("include - wrapped file missing the destination section resolves to null", func(t *testing.T) {
+		dir := t.TempDir()
+		combined := filepath.Join(dir, "combined.yaml")
+		assert.NoError(t, os.WriteFile(combined, []byte("env:\n  - name: B\n    value: b\n"), 0o644))
+
+		input := fmt.Sprintf(`alias: !include "%s"`, combined)
+		result, err := includeUnmarshaler([]byte(input))
+		assert.NoError(t, err)
+		assert.Equal(t, "alias: null", string(result))
+	})
+
+	t.Run("include - bare list file is unaffected by section extraction", func(t *testing.T) {
+		dir := t.TempDir()
+		bare := filepath.Join(dir, "bare.yaml")
+		assert.NoError(t, os.WriteFile(bare, []byte("- name: a\n  value: a\n"), 0o644))
+
+		input := fmt.Sprintf(`alias: !include "%s"`, bare)
+		result, err := includeUnmarshaler([]byte(input))
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "name: a")
+	})
+
+	t.Run("include - list item form is not eligible for section extraction", func(t *testing.T) {
+		dir := t.TempDir()
+		combined := filepath.Join(dir, "combined.yaml")
+		assert.NoError(t, os.WriteFile(combined, []byte("alias:\n  - name: a\n    value: a\n"), 0o644))
+
+		input := fmt.Sprintf("alias:\n  - !include \"%s\"\n", combined)
+		result, err := includeUnmarshaler([]byte(input))
+		assert.NoError(t, err)
+		// the whole wrapped document is spliced in raw, exactly as before this feature existed
+		assert.Contains(t, string(result), "alias:")
+		assert.Contains(t, string(result), "name: a")
+	})
+
+	t.Run("include_dir - each file contributes only its own destination section", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "python.yaml"), []byte("alias:\n  - name: a\n    value: a\nenv:\n  - name: B\n    value: b\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "bare.yaml"), []byte("- name: c\n  value: c\n"), 0o644))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "envonly.yaml"), []byte("env:\n  - name: D\n    value: d\n"), 0o644))
+
+		input := fmt.Sprintf(`alias: !include_dir "%s"`, dir)
+		result, err := includeUnmarshaler([]byte(input))
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "name: a")
+		assert.Contains(t, string(result), "name: c")
+		assert.NotContains(t, string(result), "name: B")
+		assert.NotContains(t, string(result), "name: D")
+	})
+
+	t.Run("real decode of a combined workflow file included at two different sections", func(t *testing.T) {
+		dir := t.TempDir()
+		combined := filepath.Join(dir, "python.yaml")
+		assert.NoError(t, os.WriteFile(combined, []byte(
+			"alias:\n  - name: a\n    value: a\nenv:\n  - name: B\n    value: b\n",
+		), 0o644))
+
+		input := fmt.Sprintf("alias: !include \"%s\"\nenv: !include \"%s\"\n", combined, combined)
+
+		var a Aliae
+		err := aliaeUnmarshaler(&a, []byte(input))
+		assert.NoError(t, err)
+		assert.Len(t, a.Aliae, 1)
+		assert.Equal(t, "a", a.Aliae[0].Name)
+		assert.Len(t, a.Envs, 1)
+		assert.Equal(t, "B", a.Envs[0].Name)
 	})
 }
 

--- a/src/shell/env.go
+++ b/src/shell/env.go
@@ -12,14 +12,18 @@ import (
 type Envs []*Env
 
 type Env struct {
-	Value     any      `yaml:"value"`
-	Name      string   `yaml:"name"`
-	Delimiter Template `yaml:"delimiter"`
-	If        If       `yaml:"if"`
-	Type      EnvType  `yaml:"type"`
-	template  string
-	Persist   bool `yaml:"persist"`
-	parsed    bool
+	Value       any      `yaml:"value"`
+	Name        string   `yaml:"name"`
+	Delimiter   Template `yaml:"delimiter"`
+	If          If       `yaml:"if"`
+	Type        EnvType  `yaml:"type"`
+	Description string   `yaml:"description"`
+	Option      Option   `yaml:"option"`
+	Scope       Option   `yaml:"scope"`
+	template    string
+	Persist     bool `yaml:"persist"`
+	Force       bool `yaml:"force"`
+	parsed      bool
 }
 
 func toString(value any) string {

--- a/src/shell/env_test.go
+++ b/src/shell/env_test.go
@@ -115,6 +115,68 @@ func TestEnvironmentVariable(t *testing.T) {
 	}
 }
 
+func TestEnvironmentVariablePwshOptions(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Expected string
+		Env      Env
+	}{
+		{
+			Case:     "no PowerShell fields set, stays a real environment variable",
+			Env:      Env{Name: "HELLO", Value: "world"},
+			Expected: `$env:HELLO = "world"`,
+		},
+		{
+			Case:     "description switches to Set-Variable",
+			Env:      Env{Name: "HELLO", Value: "world", Description: "a variable"},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Description "a variable"`,
+		},
+		{
+			Case:     "force switches to Set-Variable",
+			Env:      Env{Name: "HELLO", Value: "world", Force: true},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Force`,
+		},
+		{
+			Case:     "a valid option switches to Set-Variable and renders -Option",
+			Env:      Env{Name: "HELLO", Value: "world", Option: ReadOnly},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Option "ReadOnly"`,
+		},
+		{
+			Case:     "an invalid option still switches to Set-Variable but is not rendered",
+			Env:      Env{Name: "HELLO", Value: "world", Option: "NotARealOption"},
+			Expected: `Set-Variable -Name HELLO -Value "world"`,
+		},
+		{
+			Case:     "a valid scope switches to Set-Variable and renders -Scope",
+			Env:      Env{Name: "HELLO", Value: "world", Scope: Global},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Scope "Global"`,
+		},
+		{
+			Case: "all fields combined, in Set-Alias's switch order",
+			Env: Env{
+				Name:        "HELLO",
+				Value:       "world",
+				Description: "a variable",
+				Force:       true,
+				Option:      ReadOnly,
+				Scope:       Global,
+			},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Description "a variable" -Force -Option "ReadOnly" -Scope "Global"`,
+		},
+		{
+			Case:     "array value with a PowerShell field renders a real PS array",
+			Env:      Env{Name: "ARRAY", Value: "hello array world", Type: Array, Force: true},
+			Expected: `Set-Variable -Name ARRAY -Value @("hello","array","world") -Force`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc.Env.template = ""
+		context.Current = &context.Runtime{Shell: PWSH}
+		assert.Equal(t, tc.Expected, tc.Env.string(), tc.Case)
+	}
+}
+
 func TestEnvironmentVariableWithTemplate(t *testing.T) {
 	cases := []struct {
 		Case     string

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -60,6 +60,22 @@ Write-Host $message`
 }
 
 func (e *Env) pwsh() *Env {
+	// description/force/option/scope only exist on the Variable provider, not the
+	// Environment provider, so using any of them switches this entry from a real
+	// (child-process-visible) environment variable to a PowerShell-only variable.
+	if e.hasPwshOptions() {
+		switch e.Type {
+		case Array:
+			e.template = `Set-Variable -Name {{ .Name }} -Value @({{ formatArray .Value "," }}){{ if .Description }} -Description {{ formatString .Description }}{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ formatString .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ formatString .Scope }}{{ end }}` //nolint: lll
+		case String:
+			fallthrough
+		default:
+			e.template = `Set-Variable -Name {{ .Name }} -Value {{ formatString .Value }}{{ if .Description }} -Description {{ formatString .Description }}{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ formatString .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ formatString .Scope }}{{ end }}` //nolint: lll
+		}
+
+		return e
+	}
+
 	switch e.Type {
 	case Array:
 		e.template = `$env:{{ .Name }} = @({{ formatArray .Value "," }})`
@@ -70,6 +86,12 @@ func (e *Env) pwsh() *Env {
 	}
 
 	return e
+}
+
+// hasPwshOptions reports whether e sets any PowerShell Variable-provider-only
+// field, which requires rendering via Set-Variable instead of $env:.
+func (e *Env) hasPwshOptions() bool {
+	return len(e.Description) > 0 || e.Force || len(e.Option) > 0 || len(e.Scope) > 0
 }
 
 func (l *Link) pwsh() *Link {

--- a/src/shell/template.go
+++ b/src/shell/template.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	context_ "context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -61,6 +62,7 @@ func funcMap() template.FuncMap {
 		"isDir":          isDir,
 		"dirAccessible":  dirAccessible,
 		"pathAccessible": pathAccessible,
+		"wslPath":        wslPath,
 	}
 	return funcMap
 }
@@ -184,4 +186,22 @@ func dirAccessible(path string) bool {
 	}
 
 	return canTraverseDir(path)
+}
+
+// wslPath converts a Windows path to its WSL equivalent via the wslpath binary.
+// wslpath only exists inside WSL's interop layer, so its presence on PATH is
+// itself the WSL signal; path is returned unchanged when the binary isn't found
+// or fails to convert it (e.g. running natively, or the path can't be resolved).
+func wslPath(path string) string {
+	bin, err := exec.LookPath("wslpath")
+	if err != nil {
+		return path
+	}
+
+	out, err := exec.CommandContext(context_.Background(), bin, "-a", path).Output()
+	if err != nil {
+		return path
+	}
+
+	return strings.TrimSpace(string(out))
 }

--- a/src/shell/template_test.go
+++ b/src/shell/template_test.go
@@ -1,8 +1,10 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/jandedobbeleer/aliae/src/context"
@@ -278,6 +280,65 @@ func TestPathAccessible(t *testing.T) {
 		got, _ := parse(text, tc)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
+}
+
+// writeFakeBinary drops a script named "wslpath" (plus a Windows-executable
+// extension when needed) into dir that, when run, prints output and exits with
+// exitCode. It returns dir so callers can prepend it to PATH.
+func writeFakeBinary(t *testing.T, output string, exitCode int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n"
+		if len(output) > 0 {
+			script += "echo " + output + "\r\n"
+		}
+		script += fmt.Sprintf("exit /b %d\r\n", exitCode)
+
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath.cmd"), []byte(script), 0o755))
+
+		return dir
+	}
+
+	script := "#!/bin/sh\n"
+	if len(output) > 0 {
+		script += "echo " + output + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", exitCode)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath"), []byte(script), 0o755))
+
+	return dir
+}
+
+func TestWslPath(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	t.Run("wslpath not on PATH returns the input unchanged", func(t *testing.T) {
+		os.Setenv("PATH", t.TempDir())
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, got)
+	})
+
+	t.Run("wslpath converts the path", func(t *testing.T) {
+		dir := writeFakeBinary(t, "/mnt/c/Documents/theme.omp.yml", 0)
+		os.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, "/mnt/c/Documents/theme.omp.yml", got)
+	})
+
+	t.Run("wslpath failing returns the input unchanged", func(t *testing.T) {
+		dir := writeFakeBinary(t, "", 1)
+		os.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, got)
+	})
 }
 
 func TestHasCommand(t *testing.T) {

--- a/website/docs/setup/env.mdx
+++ b/website/docs/setup/env.mdx
@@ -25,6 +25,42 @@ env:
 | `persist`   | `boolean` | if you want to persist the environment variable into the registry for the current user (Windows only)   |
 | `type`      | `string`  | type to export to, possible values are `string` (default) and `array`                                   |
 
+### Shell specific configuration
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+  defaultValue="powershell"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'powershell', }
+  ]
+}>
+
+<TabItem value="powershell">
+
+:::caution
+`description`, `force`, `option`, and `scope` only exist on PowerShell's Variable provider, not
+its Environment provider. Setting any one of them switches that entry from a real environment
+variable (`$env:NAME`, visible to child processes) to a PowerShell-only variable (`$NAME`, set via
+[`Set-Variable`][set-variable], not visible to child processes). Leave them unset if the variable
+needs to be seen by anything other than the PowerShell session itself.
+:::
+
+| Name          | Type      | Description                                                                                                                                                                                                      |
+| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `description` | `string`  | specifies a description of the variable                                                                                                                                                                          |
+| `force`       | `boolean` | use the `force` parameter to change or delete a variable that has the `option` parameter set to ReadOnly. The `force` parameter cannot change or delete a variable with the `option` parameter set to `Constant` |
+| `option`      | `string`  | see the [PowerShell documentation][set-variable-option]                                                                                                                                                          |
+| `scope`       | `string`  | see the [PowerShell documentation][set-variable-scope]                                                                                                                                                           |
+
+</TabItem>
+</Tabs>
+
 [templates]: templates.mdx
 [go-text-template]: https://golang.org/pkg/text/template/
 [if]: if.mdx
+[set-variable]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable
+[set-variable-option]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-option
+[set-variable-scope]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-scope

--- a/website/docs/setup/include.mdx
+++ b/website/docs/setup/include.mdx
@@ -85,5 +85,34 @@ aliae:
     value: git
 ```
 
+## Section Files
+
+A file included directly at a section's own key (`alias: !include ...`, not the inline list-item
+form above) may itself be wrapped in one or more of Aliae's top-level keys — `alias`, `env`,
+`path`, `cdpath`, `script`, or `link` — instead of a bare list. This lets you keep everything for
+one "workflow" together in a single file, and pull only the relevant section in at each include
+site. Only the section matching the include's own key is used; any other sections in the file are
+ignored at that site.
+
+```yaml title=".aliae.yaml"
+alias: !include "{{ .Home }}/.aliae/python.yaml"
+env: !include "{{ .Home }}/.aliae/python.yaml"
+```
+
+```yaml title="$HOME/.aliae/python.yaml"
+alias:
+  - name: venv
+    value: python -m venv .venv
+env:
+  - name: PYTHONDONTWRITEBYTECODE
+    value: "1"
+```
+
+A file that doesn't carry the section being included resolves to nothing, same as a false
+[conditional include](#conditional-include). Section files can also be used with `!include_dir`:
+each file in the directory contributes only its own matching section, and a file that doesn't
+carry that section is skipped. This is not supported for the inline list-item form, since there's
+no single destination key for an entry inside an existing list.
+
 [if]: if.mdx
 [templates]: templates.mdx

--- a/website/docs/setup/templates.mdx
+++ b/website/docs/setup/templates.mdx
@@ -32,6 +32,13 @@ Out of the box you get the following functionality:
 | `hasCommand`     | `boolean` | check if an executable exists                               | `{{ hasCommand "oh-my-posh" }}`                                              |
 | `dirAccessible`  | `boolean` | check if a directory exists and is traversable              | `{{ dirAccessible "/opt/homebrew/bin" }}`                                    |
 | `pathAccessible` | `boolean` | check if a path exists and is readable                      | `{{ pathAccessible "/etc/hosts" }}`                                          |
+| `wslPath`        | `string`  | convert a Windows path to its WSL equivalent                | `{{ wslPath "C:\\Documents\\theme.omp.yml" }}`                               |
+
+:::tip
+`wslPath` relies on the `wslpath` binary, which only exists inside WSL's interop layer. Outside
+WSL (or if the binary can't convert the given path) it returns the path unchanged, so it's safe to
+use unconditionally in a config shared across machines.
+:::
 
 :::tip
 When using a template in a single line, you have to use quotes to wrap the template string.

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -81,6 +81,22 @@
                             "string",
                             "array"
                         ]
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "PowerShell only: specifies a description for the variable. Setting this, force, option, or scope switches this entry from a real environment variable to a PowerShell-only variable (Set-Variable), no longer visible to child processes"
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "PowerShell only: use the force parameter to change or delete a variable that has the option parameter set to ReadOnly. The Force parameter cannot change or delete a variable with the option parameter set to Constant"
+                    },
+                    "option": {
+                        "type": "string",
+                        "description": "PowerShell only: see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-option"
+                    },
+                    "scope": {
+                        "type": "string",
+                        "description": "PowerShell only: see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-scope"
                     }
                 }
             }


### PR DESCRIPTION
A file included directly at a section's own key (alias: !include ...) may now be wrapped in a top-level alias/env/path/cdpath/script/link key instead of a bare list, so a single "workflow" file can be included separately at each matching section, pulling only its own part. Unwrapped files are unaffected. Not supported for the inline list-item form, since there's no single destination key to match.

Closes #284

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://aliae.dev/docs/contributing/git) to help you out.
aliae advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/aliae/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
