### PR TITLE
feat(shell): add wslPath template function

### DIFF
--- a/src/shell/template.go
+++ b/src/shell/template.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	context_ "context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -61,6 +62,7 @@ func funcMap() template.FuncMap {
 		"isDir":          isDir,
 		"dirAccessible":  dirAccessible,
 		"pathAccessible": pathAccessible,
+		"wslPath":        wslPath,
 	}
 	return funcMap
 }
@@ -184,4 +186,22 @@ func dirAccessible(path string) bool {
 	}
 
 	return canTraverseDir(path)
+}
+
+// wslPath converts a Windows path to its WSL equivalent via the wslpath binary.
+// wslpath only exists inside WSL's interop layer, so its presence on PATH is
+// itself the WSL signal; path is returned unchanged when the binary isn't found
+// or fails to convert it (e.g. running natively, or the path can't be resolved).
+func wslPath(path string) string {
+	bin, err := exec.LookPath("wslpath")
+	if err != nil {
+		return path
+	}
+
+	out, err := exec.CommandContext(context_.Background(), bin, "-a", path).Output()
+	if err != nil {
+		return path
+	}
+
+	return strings.TrimSpace(string(out))
 }

--- a/src/shell/template_test.go
+++ b/src/shell/template_test.go
@@ -1,8 +1,10 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/jandedobbeleer/aliae/src/context"
@@ -278,6 +280,65 @@ func TestPathAccessible(t *testing.T) {
 		got, _ := parse(text, tc)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
+}
+
+// writeFakeBinary drops a script named "wslpath" (plus a Windows-executable
+// extension when needed) into dir that, when run, prints output and exits with
+// exitCode. It returns dir so callers can prepend it to PATH.
+func writeFakeBinary(t *testing.T, output string, exitCode int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n"
+		if len(output) > 0 {
+			script += "echo " + output + "\r\n"
+		}
+		script += fmt.Sprintf("exit /b %d\r\n", exitCode)
+
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath.cmd"), []byte(script), 0o755))
+
+		return dir
+	}
+
+	script := "#!/bin/sh\n"
+	if len(output) > 0 {
+		script += "echo " + output + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", exitCode)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath"), []byte(script), 0o755))
+
+	return dir
+}
+
+func TestWslPath(t *testing.T) {
+	origPath := os.Getenv("PATH")
+	t.Cleanup(func() { os.Setenv("PATH", origPath) })
+
+	t.Run("wslpath not on PATH returns the input unchanged", func(t *testing.T) {
+		os.Setenv("PATH", t.TempDir())
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, got)
+	})
+
+	t.Run("wslpath converts the path", func(t *testing.T) {
+		dir := writeFakeBinary(t, "/mnt/c/Documents/theme.omp.yml", 0)
+		os.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, "/mnt/c/Documents/theme.omp.yml", got)
+	})
+
+	t.Run("wslpath failing returns the input unchanged", func(t *testing.T) {
+		dir := writeFakeBinary(t, "", 1)
+		os.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+
+		got := wslPath(`C:\Documents\theme.omp.yml`)
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, got)
+	})
 }
 
 func TestHasCommand(t *testing.T) {

--- a/website/docs/setup/templates.mdx
+++ b/website/docs/setup/templates.mdx
@@ -32,6 +32,13 @@ Out of the box you get the following functionality:
 | `hasCommand`     | `boolean` | check if an executable exists                               | `{{ hasCommand "oh-my-posh" }}`                                              |
 | `dirAccessible`  | `boolean` | check if a directory exists and is traversable              | `{{ dirAccessible "/opt/homebrew/bin" }}`                                    |
 | `pathAccessible` | `boolean` | check if a path exists and is readable                      | `{{ pathAccessible "/etc/hosts" }}`                                          |
+| `wslPath`        | `string`  | convert a Windows path to its WSL equivalent                | `{{ wslPath "C:\\Documents\\theme.omp.yml" }}`                               |
+
+:::tip
+`wslPath` relies on the `wslpath` binary, which only exists inside WSL's interop layer. Outside
+WSL (or if the binary can't convert the given path) it returns the path unchanged, so it's safe to
+use unconditionally in a config shared across machines.
+:::
 
 :::tip
 When using a template in a single line, you have to use quotes to wrap the template string.


### PR DESCRIPTION
## Summary

- Reopens #32 with a narrower scope than originally requested: WSL only (not Git Bash), explicit opt-in via template function (not automatic whole-value conversion — the original thread's disagreement was specifically about that), using WSL's own `wslpath` binary rather than hand-rolled drive-letter parsing.
- New `wslPath` template function, usable anywhere templates evaluate (`env:`, `path:`, `cdpath:`, `script:`, ...), not limited to a new `Env` struct field. `exec.LookPath("wslpath")` is itself the WSL detection — the binary only exists inside WSL's interop layer, so no separate `isWSL()`/env-var check was needed.
- Tolerant fallback ladder: binary not found, or `wslpath` fails to convert → return the input unchanged. Safe to use unconditionally in a config shared across machines/shells.

```yaml
env:
  - name: POSH_THEME
    value: '{{ wslPath "C:\Documents\theme.omp.yml" }}'
```

A struct-field design (`convert: true` on `Env`) was considered and rejected: it doesn't extend to `path:`/`cdpath:`/`script:` without repeating the field on every struct, can't express "convert to what" if Git Bash support is added later without a breaking change to the key, and `Env.Value` isn't guaranteed to be a plain string (array values get delimiter-joined), which the template-function approach sidesteps entirely (string in, string out).

Closes #32

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — new `TestWslPath` covers binary-absent, successful conversion, and binary-failure paths using a fake cross-platform `wslpath` script on a scoped `PATH`
- [x] `modernize --fix ./...` / `fieldalignment --fix ./...` — no changes
- [x] `go mod tidy` — no changes
- [x] `gofmt` / `golangci-lint run` — zero issues
- [x] `npx markdownlint-cli2` on the doc change — no new violations (pre-existing table width issue in this file predates this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)