### PR TITLE
feat(shell): support PowerShell variable switches on env entries

### DIFF
--- a/src/shell/env.go
+++ b/src/shell/env.go
@@ -12,14 +12,18 @@ import (
 type Envs []*Env
 
 type Env struct {
-	Value     any      `yaml:"value"`
-	Name      string   `yaml:"name"`
-	Delimiter Template `yaml:"delimiter"`
-	If        If       `yaml:"if"`
-	Type      EnvType  `yaml:"type"`
-	template  string
-	Persist   bool `yaml:"persist"`
-	parsed    bool
+	Value       any      `yaml:"value"`
+	Name        string   `yaml:"name"`
+	Delimiter   Template `yaml:"delimiter"`
+	If          If       `yaml:"if"`
+	Type        EnvType  `yaml:"type"`
+	Description string   `yaml:"description"`
+	Option      Option   `yaml:"option"`
+	Scope       Option   `yaml:"scope"`
+	template    string
+	Persist     bool `yaml:"persist"`
+	Force       bool `yaml:"force"`
+	parsed      bool
 }
 
 func toString(value any) string {

--- a/src/shell/env_test.go
+++ b/src/shell/env_test.go
@@ -115,6 +115,68 @@ func TestEnvironmentVariable(t *testing.T) {
 	}
 }
 
+func TestEnvironmentVariablePwshOptions(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Expected string
+		Env      Env
+	}{
+		{
+			Case:     "no PowerShell fields set, stays a real environment variable",
+			Env:      Env{Name: "HELLO", Value: "world"},
+			Expected: `$env:HELLO = "world"`,
+		},
+		{
+			Case:     "description switches to Set-Variable",
+			Env:      Env{Name: "HELLO", Value: "world", Description: "a variable"},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Description "a variable"`,
+		},
+		{
+			Case:     "force switches to Set-Variable",
+			Env:      Env{Name: "HELLO", Value: "world", Force: true},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Force`,
+		},
+		{
+			Case:     "a valid option switches to Set-Variable and renders -Option",
+			Env:      Env{Name: "HELLO", Value: "world", Option: ReadOnly},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Option "ReadOnly"`,
+		},
+		{
+			Case:     "an invalid option still switches to Set-Variable but is not rendered",
+			Env:      Env{Name: "HELLO", Value: "world", Option: "NotARealOption"},
+			Expected: `Set-Variable -Name HELLO -Value "world"`,
+		},
+		{
+			Case:     "a valid scope switches to Set-Variable and renders -Scope",
+			Env:      Env{Name: "HELLO", Value: "world", Scope: Global},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Scope "Global"`,
+		},
+		{
+			Case: "all fields combined, in Set-Alias's switch order",
+			Env: Env{
+				Name:        "HELLO",
+				Value:       "world",
+				Description: "a variable",
+				Force:       true,
+				Option:      ReadOnly,
+				Scope:       Global,
+			},
+			Expected: `Set-Variable -Name HELLO -Value "world" -Description "a variable" -Force -Option "ReadOnly" -Scope "Global"`,
+		},
+		{
+			Case:     "array value with a PowerShell field renders a real PS array",
+			Env:      Env{Name: "ARRAY", Value: "hello array world", Type: Array, Force: true},
+			Expected: `Set-Variable -Name ARRAY -Value @("hello","array","world") -Force`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc.Env.template = ""
+		context.Current = &context.Runtime{Shell: PWSH}
+		assert.Equal(t, tc.Expected, tc.Env.string(), tc.Case)
+	}
+}
+
 func TestEnvironmentVariableWithTemplate(t *testing.T) {
 	cases := []struct {
 		Case     string

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -60,6 +60,22 @@ Write-Host $message`
 }
 
 func (e *Env) pwsh() *Env {
+	// description/force/option/scope only exist on the Variable provider, not the
+	// Environment provider, so using any of them switches this entry from a real
+	// (child-process-visible) environment variable to a PowerShell-only variable.
+	if e.hasPwshOptions() {
+		switch e.Type {
+		case Array:
+			e.template = `Set-Variable -Name {{ .Name }} -Value @({{ formatArray .Value "," }}){{ if .Description }} -Description {{ formatString .Description }}{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ formatString .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ formatString .Scope }}{{ end }}` //nolint: lll
+		case String:
+			fallthrough
+		default:
+			e.template = `Set-Variable -Name {{ .Name }} -Value {{ formatString .Value }}{{ if .Description }} -Description {{ formatString .Description }}{{ end }}{{ if .Force }} -Force{{ end }}{{ if isPwshOption .Option }} -Option {{ formatString .Option }}{{ end }}{{ if isPwshScope .Scope }} -Scope {{ formatString .Scope }}{{ end }}` //nolint: lll
+		}
+
+		return e
+	}
+
 	switch e.Type {
 	case Array:
 		e.template = `$env:{{ .Name }} = @({{ formatArray .Value "," }})`
@@ -70,6 +86,12 @@ func (e *Env) pwsh() *Env {
 	}
 
 	return e
+}
+
+// hasPwshOptions reports whether e sets any PowerShell Variable-provider-only
+// field, which requires rendering via Set-Variable instead of $env:.
+func (e *Env) hasPwshOptions() bool {
+	return len(e.Description) > 0 || e.Force || len(e.Option) > 0 || len(e.Scope) > 0
 }
 
 func (l *Link) pwsh() *Link {

--- a/website/docs/setup/env.mdx
+++ b/website/docs/setup/env.mdx
@@ -25,6 +25,42 @@ env:
 | `persist`   | `boolean` | if you want to persist the environment variable into the registry for the current user (Windows only)   |
 | `type`      | `string`  | type to export to, possible values are `string` (default) and `array`                                   |
 
+### Shell specific configuration
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+  defaultValue="powershell"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'powershell', }
+  ]
+}>
+
+<TabItem value="powershell">
+
+:::caution
+`description`, `force`, `option`, and `scope` only exist on PowerShell's Variable provider, not
+its Environment provider. Setting any one of them switches that entry from a real environment
+variable (`$env:NAME`, visible to child processes) to a PowerShell-only variable (`$NAME`, set via
+[`Set-Variable`][set-variable], not visible to child processes). Leave them unset if the variable
+needs to be seen by anything other than the PowerShell session itself.
+:::
+
+| Name          | Type      | Description                                                                                                                                                                                                      |
+| ------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `description` | `string`  | specifies a description of the variable                                                                                                                                                                          |
+| `force`       | `boolean` | use the `force` parameter to change or delete a variable that has the `option` parameter set to ReadOnly. The `force` parameter cannot change or delete a variable with the `option` parameter set to `Constant` |
+| `option`      | `string`  | see the [PowerShell documentation][set-variable-option]                                                                                                                                                          |
+| `scope`       | `string`  | see the [PowerShell documentation][set-variable-scope]                                                                                                                                                           |
+
+</TabItem>
+</Tabs>
+
 [templates]: templates.mdx
 [go-text-template]: https://golang.org/pkg/text/template/
 [if]: if.mdx
+[set-variable]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable
+[set-variable-option]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-option
+[set-variable-scope]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-scope

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -81,6 +81,22 @@
                             "string",
                             "array"
                         ]
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "PowerShell only: specifies a description for the variable. Setting this, force, option, or scope switches this entry from a real environment variable to a PowerShell-only variable (Set-Variable), no longer visible to child processes"
+                    },
+                    "force": {
+                        "type": "boolean",
+                        "description": "PowerShell only: use the force parameter to change or delete a variable that has the option parameter set to ReadOnly. The Force parameter cannot change or delete a variable with the option parameter set to Constant"
+                    },
+                    "option": {
+                        "type": "string",
+                        "description": "PowerShell only: see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-option"
+                    },
+                    "scope": {
+                        "type": "string",
+                        "description": "PowerShell only: see https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/set-variable#-scope"
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- Adds `description`/`force`/`option`/`scope` to `env:` entries, mirroring the fields already available on `alias:` entries — the PowerShell-specific request in #100.
- These fields only exist on PowerShell's **Variable** provider (`Set-Variable`), not its **Environment** provider (`$env:`). An `env:` entry that sets any one of them now renders via `Set-Variable` instead of `$env:X = value`. Entries that don't set any of these fields are completely unaffected and keep exporting a real, child-process-visible environment variable — exactly today's behavior, unchanged.
- This is a deliberate, conditional trade-off rather than an unconditional switch: aliae's `env:` is documented as "the same environment variable cross shell," and the flagship example everywhere in the docs (`POSH_THEME`) is read by a separate binary (oh-my-posh) via `os.Getenv` — a PowerShell session variable (`Set-Variable`) is invisible to child processes, so switching every entry unconditionally would silently break that. Opting into any of the four new fields is what signals "I want PowerShell-variable semantics for this one."
- `Set-Variable` (not `New-Variable`) was chosen to match the existing `Set-Alias` (not `New-Alias`) precedent — create-or-update, so re-sourcing a profile in a new shell tab stays idempotent.
- Documented the trade-off explicitly in `env.mdx` (new "Shell specific configuration" section, mirroring `alias.mdx`'s existing one) and added the four fields to `schema.json`.

```yaml
env:
  - name: SOME_TOKEN
    value: "{{ env \"SOME_TOKEN\" }}"
    option: ReadOnly
    force: true
```

Closes #100

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — new `TestEnvironmentVariablePwshOptions` covers: no PS fields (unchanged `$env:`), each field individually, an invalid `option` value (still switches to `Set-Variable`, but the invalid switch itself is omitted), all four combined (in `Set-Alias`'s established switch order), and the `Array` type rendering a real PS array via `Set-Variable`
- [x] `modernize --fix ./...` / `fieldalignment --fix ./...` — no changes
- [x] `go mod tidy` — no changes
- [x] `gofmt` / `golangci-lint run` — zero issues
- [x] `npx markdownlint-cli2` on the doc change — same pre-existing violation classes as `alias.mdx` (MD001 heading jump, MD033 `TabItem`, MD013 wide reference table — inherent to this doc site's existing Tabs/table convention), no new violation types introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)